### PR TITLE
feat: override default React Query staleTime, setting it to 5 mins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { AuthProvider } from './contexts/Auth';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Components
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import CSSBaseline from '@mui/material/CssBaseline';
 import App from './App';
 
@@ -15,7 +16,26 @@ import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/500.css';
 import '@fontsource/roboto/700.css';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      /**
+       * staleTime: 5 mins -> stale after 5 mins
+       * Default cacheTime: 5 mins -> expire cache after 5 mins
+       
+       * When data is stale AND cache is VALID, data is read from the cache and re-fetched in the BACKGROUND 
+       * The fresh data is used for the next render
+       * So (when using isLoading) a UI loading state is NOT visible 
+       
+       * When data is stale AND cache is EXPIRED, data CANNOT be read from the cache
+       * The data is re-fetched in the FOREGROUND (i.e. UI loading state is visible) and then cached
+       
+       * Whilst data is fresh, it is always read from the cache and avoids refetching and rendering loading UIs on component remounts - e.g. when navigating through browser history
+       */
+      staleTime: 1000 * 60 * 5,
+    },
+  },
+});
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -25,6 +45,7 @@ root.render(
         <AuthProvider>
           <CSSBaseline />
           <App />
+          {process.env?.NODE_ENV === 'development' && <ReactQueryDevtools />}
         </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,24 +7,16 @@ import PageWrapper from '../components/PageWrapper';
 import DisplayMessage from '../components/DisplayMessage';
 import PageSpinner from '../components/PageSpinner';
 import PreviewCard from '../components/PreviewCard';
-import { useEffect } from 'react';
-
-// 15 minutes in milliseconds
-const refetchInterval = 60 * 1000 * 15;
 
 // Render Previews of Reviews
 const Home = () => {
   const {
-    isFetching,
+    isLoading,
     error,
     data: reviews,
-  } = useQuery(['reviews'], gamesApi.fetchAllReviews, { refetchInterval });
+  } = useQuery(['reviews'], gamesApi.fetchAllReviews);
 
-  useEffect(() => {
-    console.log({ reviews });
-  }, [reviews]);
-
-  if (isFetching) {
+  if (isLoading) {
     return (
       <PageWrapper heading="Reviews">
         <PageSpinner />

--- a/src/pages/Review.jsx
+++ b/src/pages/Review.jsx
@@ -12,7 +12,6 @@ import StyledChip from '../components/StyledChip';
 // Utils
 import getDateStringFromTimestamp from '../utils/get-date-string-from-timestamp';
 import ReviewComments from '../components/ReviewComments';
-import { useEffect } from 'react';
 
 const ReviewSection = ({ children }) => {
   return (
@@ -27,28 +26,21 @@ const ReviewSection = ({ children }) => {
 const Review = () => {
   const { review_id } = useParams();
   const {
-    isFetching: fetchingReview,
+    isLoading: loadingReview,
     error: errorReview,
     data: review,
-  } = useQuery(['review', review_id], gamesApi.fetchReviewById, {
-    // refetchInterval: 15 * 60 * 1000,
-    refetchOnMount: false,
-  });
+  } = useQuery(['review', review_id], gamesApi.fetchReviewById);
 
-  // Dependent query - only executes if review was fetched successfully
+  // Dependent query - only executes if enabled property evaluates to true - i.e. review was fetched successfully
   const {
-    isFetching: fetchingComments,
+    isLoading: loadingComments,
     error: errorComments,
     data: comments,
   } = useQuery(['comments', review_id], gamesApi.fetchCommentsByReviewId, {
     enabled: !!review,
   });
 
-  useEffect(() => {
-    console.log({ review, comments });
-  }, [review, comments]);
-
-  if (fetchingReview || fetchingComments) {
+  if (loadingReview || loadingComments) {
     return (
       <PageWrapper heading="Review">
         <PageSpinner />


### PR DESCRIPTION
Purpose:
- so that UI reloads only show when cache expires (after 5 mins)
- data is read from the cache when navigating the app
- when the cache expires the data is refetched and the new data is cached